### PR TITLE
Move fs-extra from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "chokidar": "1.6.0",
     "download": "^4.4.3",
     "fs": "0.0.2",
+    "fs-extra": "^0.26.5",
     "glob": "^7.0.0",
     "lodash": "^4.5.1",
     "loglevel": "^1.4.0",
@@ -42,7 +43,6 @@
   "devDependencies": {
     "assert": "1.4.1",
     "coffee-script": "^1.10.0",
-    "fs-extra": "^0.26.5",
     "gulp": "^3.9.1",
     "gulp-coffee": "^2.3.2",
     "gulp-coffeelint": "^0.6.0",


### PR DESCRIPTION
It is depended upon at release/js/lib/server-api/server-api.js:2
